### PR TITLE
Because fuck Google

### DIFF
--- a/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
+++ b/overlay/common/frameworks/base/packages/SettingsProvider/res/values/defaults.xml
@@ -15,6 +15,11 @@
      limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
     <!-- Googles Backup transport service -->
     <string name="def_backup_transport">com.google.android.gms/.backup.BackupTransportService</string>
+
+    <!-- Because fuck Google -->
+    <bool name="def_package_verifier_enable">false</bool>
+
 </resources>


### PR DESCRIPTION
- Disable package verifier by default

With March's security updates, Google updated their Google services and now
this is getting in the way of Titanium backup and Substratum. Two things that
our users use A LOT!

If anyone is scared that the Boogeyman is going to get them, don't download
pirated apps and you'll be good! :-)

Change-Id: I025e4f599c1fafea12b3471c85b476e7b0a2afa7